### PR TITLE
fix: backfill starved channels/threads first so empty threads get data

### DIFF
--- a/scripts/export_channels.py
+++ b/scripts/export_channels.py
@@ -14,6 +14,7 @@ from typing import Any
 from scripts.channel_classifier import ChannelType, classify_channel, sanitize_thread_name
 from scripts.config import load_config
 from scripts.months import (
+    count_nonempty_months,
     current_month_utc,
     month_bounds,
     month_range_iter,
@@ -56,6 +57,33 @@ class MediaConfig:
     reuse_media: bool = False
 
 
+def _channel_identity(
+    channel: dict[str, str | None],
+    channel_type: ChannelType,
+    channel_id: str,
+    channel_path_map: dict[str, str],
+) -> tuple[str, str]:
+    """Pure (no filesystem) → (safe_name, forum_name) for a channel/thread.
+
+    `forum_name` is the parent forum's full hierarchical path for threads,
+    or "" for regular channels. Used both to place exports and to derive
+    the public path when ranking backfill priority (so it must NOT mkdir).
+    """
+    if channel_type == ChannelType.THREAD:
+        forum_name_raw = channel.get("parent_id")
+        forum_name_simple: str = forum_name_raw if forum_name_raw else "unknown-forum"
+        # If forum "cob" is inside "🏗️ - Designing", path_map maps
+        # "cob" -> "🏗️ - Designing/cob".
+        forum_full_path = channel_path_map.get(forum_name_simple, forum_name_simple)
+        channel_name_raw = channel.get("name")
+        safe_name = sanitize_thread_name(
+            channel_name_raw if channel_name_raw else "unknown", channel_id
+        )
+        return safe_name, forum_full_path
+    channel_name_raw = channel.get("name")
+    return (channel_name_raw if channel_name_raw else "unknown"), ""
+
+
 def _determine_export_location(
     channel: dict[str, str | None],
     channel_type: ChannelType,
@@ -65,39 +93,17 @@ def _determine_export_location(
 ) -> tuple[str, Path, str]:
     """Determine the per-channel export directory and the safe name.
 
-    Returns a tuple of (safe_name, channel_export_dir, forum_name):
-
-      - `safe_name`: filesystem-safe identifier for this channel/thread
-      - `channel_export_dir`: the directory inside `exports/` where this
-        channel's per-month files (`{YYYY-MM}.html` etc.) will be written.
-        For regular channels this is `exports/server/{channel}/`; for
-        threads it is `exports/server/{forum_path}/{thread}/`.
-      - `forum_name`: the parent forum's full path for threads, or ""
+    Returns (safe_name, channel_export_dir, forum_name). For regular
+    channels the dir is `exports/server/{channel}/`; for threads it is
+    `exports/server/{forum_path}/{thread}/`. Creates the directory.
     """
+    safe_name, forum_name = _channel_identity(channel, channel_type, channel_id, channel_path_map)
     if channel_type == ChannelType.THREAD:
-        forum_name_raw = channel.get("parent_id")
-        forum_name_simple: str = forum_name_raw if forum_name_raw else "unknown-forum"
-
-        # Look up the full hierarchical path for the forum
-        # If forum is "cob" inside "🏗️ - Designing", path_map will have "cob" -> "🏗️ - Designing/cob"
-        forum_full_path = channel_path_map.get(forum_name_simple, forum_name_simple)
-
-        channel_name_raw = channel.get("name")
-        safe_name = sanitize_thread_name(
-            channel_name_raw if channel_name_raw else "unknown", channel_id
-        )
-        # Per-month files go into exports/server/forum/thread-name/
-        thread_export_dir = server_dir / forum_full_path / safe_name
-        thread_export_dir.mkdir(parents=True, exist_ok=True)
-        return safe_name, thread_export_dir, forum_full_path
+        channel_export_dir = server_dir / forum_name / safe_name
     else:
-        # Regular channel
-        channel_name_raw = channel.get("name")
-        channel_name = channel_name_raw if channel_name_raw else "unknown"
-        # Per-month files go into exports/server/channel-name/
-        channel_export_dir = server_dir / channel_name
-        channel_export_dir.mkdir(parents=True, exist_ok=True)
-        return channel_name, channel_export_dir, ""
+        channel_export_dir = server_dir / safe_name
+    channel_export_dir.mkdir(parents=True, exist_ok=True)
+    return safe_name, channel_export_dir, forum_name
 
 
 def _public_channel_dir(
@@ -350,6 +356,63 @@ class _TimeBudget:
         return int(time.monotonic() - self.start)
 
 
+def _backfill_priority_key(
+    channel: dict[str, str | None],
+    channel_type: ChannelType,
+    server_key: str,
+    channel_path_map: dict[str, str],
+    public_dir: Path,
+) -> tuple[int, str]:
+    """Sort key for the backfill phase: starved entries first.
+
+    Returns (non_empty_month_count, channel_id). Sorting ascending puts
+    channels/threads with the LEAST real data first, so threads showing
+    only an empty current-month export ("empty threads" the user sees)
+    get their historical months backfilled before time is spent on
+    already-rich channels. Within a tie, sort by channel id for stable
+    ordering across runs.
+    """
+    chan_id = channel.get("id") or ""
+    if not chan_id:
+        return (0, chan_id)
+    try:
+        safe_name, forum_name = _channel_identity(channel, channel_type, chan_id, channel_path_map)
+    except Exception:  # noqa: BLE001 — never let sorting crash the run
+        return (0, chan_id)
+    pub = _public_channel_dir(public_dir, server_key, channel_type, safe_name, forum_name)
+    return (count_nonempty_months(pub), chan_id)
+
+
+def _ordered_channels_for_phase(  # noqa: PLR0913  # needs full per-server context
+    phase: str,
+    channels: list[dict[str, str | None]],
+    channel_classifications: dict[str, ChannelType],
+    server_key: str,
+    channel_path_map: dict[str, str],
+    public_dir: Path,
+) -> list[dict[str, str | None]]:
+    """Order `channels` for a phase, starved entries first when backfilling.
+
+    Phase 1 keeps the natural listing order (every channel gets its current
+    month; order doesn't affect completeness). Phase 2 (backfill) puts the
+    most-starved entries first so 'empty thread' cases get real data within
+    one or two runs rather than waiting for the fixed-order frontier to
+    crawl past.
+    """
+    if phase != PHASE_BACKFILL:
+        return channels
+    return sorted(
+        channels,
+        key=lambda c: _backfill_priority_key(
+            c,
+            channel_classifications.get(c.get("id") or "", ChannelType.REGULAR),
+            server_key,
+            channel_path_map,
+            public_dir,
+        ),
+    )
+
+
 def _run_export_phase(  # noqa: PLR0913  # phase runner needs the per-server context
     phase: str,
     channels: list[dict[str, str | None]],
@@ -367,7 +430,15 @@ def _run_export_phase(  # noqa: PLR0913  # phase runner needs the per-server con
     Returns False if the time budget was exhausted mid-phase (the caller
     should stop and let the next workflow run resume), True otherwise.
     """
-    for channel in channels:
+    ordered = _ordered_channels_for_phase(
+        phase,
+        channels,
+        channel_classifications,
+        context.server_key,
+        channel_path_map,
+        public_dir,
+    )
+    for channel in ordered:
         if budget.exhausted():
             summary["time_budget_exhausted"] = True
             print(

--- a/scripts/months.py
+++ b/scripts/months.py
@@ -141,6 +141,37 @@ def scan_completed_months(channel_dir: Path) -> set[str]:
     return completed
 
 
+# An empty DCE per-month JSON (0 messages) is the guild/channel/dateRange
+# scaffold only — measured at ~487-522 bytes on the live archive. A month
+# with even one message is multiple KB. 1500 bytes cleanly separates the
+# two without parsing the file (a cheap os.stat), which matters when
+# ranking hundreds of channels/threads by neediness every run.
+EMPTY_MONTH_JSON_MAX_BYTES = 1500
+
+
+def count_nonempty_months(channel_dir: Path) -> int:
+    """Count months in `channel_dir` whose JSON is larger than an empty export.
+
+    Used to rank backfill priority: an entry with 0 non-empty months is a
+    "starved" channel/thread (only an empty current-month export exists)
+    and must be backfilled before entries that already have real data.
+    Uses file size (os.stat) rather than parsing — fast at scale.
+    """
+    if not channel_dir.exists() or not channel_dir.is_dir():
+        return 0
+    count = 0
+    for entry in channel_dir.iterdir():
+        if not entry.is_dir() or not is_month_dir_name(entry.name):
+            continue
+        json_file = entry / f"{entry.name}.json"
+        try:
+            if json_file.stat().st_size > EMPTY_MONTH_JSON_MAX_BYTES:
+                count += 1
+        except OSError:
+            continue
+    return count
+
+
 def _json_is_month_pure(json_file: Path, month: str) -> bool:
     """Return True iff every message in the JSON is timestamped within `month`.
 

--- a/tests/test_export_orchestration.py
+++ b/tests/test_export_orchestration.py
@@ -909,3 +909,61 @@ commit_author = "Test Bot"
                                     assert thread_calls[0].kwargs["before_timestamp"] is None
 
         del os.environ["DISCORD_BOT_TOKEN"]
+
+
+class TestBackfillOrdering:
+    """The backfill phase must visit starved entries before data-rich ones.
+
+    This is the root-cause fix for "empty threads": with a fixed listing
+    order the time budget was exhausted long before the frontier reached
+    most threads, so they only ever got an empty current-month export.
+    Ordering Phase 2 by neediness means a thread with zero real data is
+    backfilled within a run or two instead of waiting for the crawl.
+    """
+
+    def _make_month(self, channel_dir: Path, month: str, json_bytes: int) -> None:
+        """Write a month export whose JSON is exactly `json_bytes` long."""
+        month_dir = channel_dir / month
+        month_dir.mkdir(parents=True, exist_ok=True)
+        (month_dir / f"{month}.html").write_text("<html></html>")
+        (month_dir / f"{month}.json").write_text("x" * json_bytes)
+
+    def test_backfill_orders_starved_channel_first(self, tmp_path: Path) -> None:
+        """A channel with only an empty current month sorts before a rich one."""
+        from scripts.channel_classifier import ChannelType
+        from scripts.export_channels import PHASE_BACKFILL, _ordered_channels_for_phase
+
+        public = tmp_path / "public"
+        server = "wafer-space"
+        # rich-channel already has a real (large JSON) past month.
+        self._make_month(public / server / "rich-channel", "2026-03", 5000)
+        # starved-channel only has a tiny empty current-month export.
+        self._make_month(public / server / "starved-channel", "2026-05", 15)
+
+        rich: dict[str, str | None] = {"id": "100", "name": "rich-channel"}
+        starved: dict[str, str | None] = {"id": "200", "name": "starved-channel"}
+        classifications = {"100": ChannelType.REGULAR, "200": ChannelType.REGULAR}
+
+        # Pass them rich-first so order is only correct if we actually sort.
+        ordered = _ordered_channels_for_phase(
+            PHASE_BACKFILL, [rich, starved], classifications, server, {}, public
+        )
+        assert [c["name"] for c in ordered] == ["starved-channel", "rich-channel"]
+
+    def test_current_phase_preserves_listing_order(self, tmp_path: Path) -> None:
+        """Phase 1 (current month) is left in natural order — order is irrelevant
+        to completeness there and re-sorting would just add cost every run."""
+        from scripts.channel_classifier import ChannelType
+        from scripts.export_channels import PHASE_CURRENT, _ordered_channels_for_phase
+
+        public = tmp_path / "public"
+        self._make_month(public / "wafer-space" / "rich-channel", "2026-03", 5000)
+
+        rich: dict[str, str | None] = {"id": "100", "name": "rich-channel"}
+        starved: dict[str, str | None] = {"id": "200", "name": "starved-channel"}
+        classifications = {"100": ChannelType.REGULAR, "200": ChannelType.REGULAR}
+
+        ordered = _ordered_channels_for_phase(
+            PHASE_CURRENT, [rich, starved], classifications, "wafer-space", {}, public
+        )
+        assert ordered == [rich, starved]

--- a/tests/test_months.py
+++ b/tests/test_months.py
@@ -231,3 +231,42 @@ def test_scan_completed_months_treats_empty_json_as_complete(tmp_path: Path) -> 
 
     completed = scan_completed_months(channel_dir)
     assert completed == {"2026-03"}
+
+
+def test_count_nonempty_months_uses_json_size(tmp_path: Path) -> None:
+    """count_nonempty_months counts months whose JSON is bigger than an empty
+    DCE export (a cheap os.stat heuristic — empty 0-message JSON is ~500B,
+    one with messages is multi-KB). Used to prioritize starved entries.
+    """
+    from scripts.months import count_nonempty_months
+
+    chan = tmp_path / "thread-a"
+    # Empty current-month export: tiny JSON (DCE 0-message scaffold ~500B).
+    (chan / "2026-05").mkdir(parents=True)
+    (chan / "2026-05" / "2026-05.html").write_text("<html>0</html>")
+    (chan / "2026-05" / "2026-05.json").write_text('{"messages":[]}')  # ~15B
+    # A month with real messages: large JSON.
+    (chan / "2026-03").mkdir(parents=True)
+    (chan / "2026-03" / "2026-03.html").write_text("<html>real</html>")
+    (chan / "2026-03" / "2026-03.json").write_text("x" * 5000)
+
+    assert count_nonempty_months(chan) == 1  # only 2026-03 has real data
+
+
+def test_count_nonempty_months_zero_for_only_empty(tmp_path: Path) -> None:
+    """A thread that only has an empty current-month export counts as 0 —
+    this is exactly the 'empty thread' case that must be prioritized."""
+    from scripts.months import count_nonempty_months
+
+    chan = tmp_path / "starved-thread"
+    (chan / "2026-05").mkdir(parents=True)
+    (chan / "2026-05" / "2026-05.json").write_text('{"messages":[]}')
+
+    assert count_nonempty_months(chan) == 0
+
+
+def test_count_nonempty_months_missing_dir_is_zero(tmp_path: Path) -> None:
+    """No public dir yet → zero non-empty months (maximally starved)."""
+    from scripts.months import count_nonempty_months
+
+    assert count_nonempty_months(tmp_path / "nope") == 0


### PR DESCRIPTION
## Problem

Threads on the live site appear **empty** (only an empty current-month export). This is not a data problem — Discord requires a message to create a thread, so the data exists. The cause is **scheduling**: the backfill phase (Phase 2) walked channels in fixed listing order, and the time budget was exhausted partway through (~the "D" range), so threads later in the list never had their historical months exported.

## Fix (scheduling, not filtering)

Order Phase 2 by **neediness** — entries with the fewest non-empty months go first — so a zero-data thread gets real history within a run or two instead of waiting for the fixed-order frontier to crawl past it.

- `months.count_nonempty_months()` — cheap `os.stat` heuristic (empty DCE JSON ~500B, real months multi-KB; 1500B threshold) to rank neediness without parsing.
- `export_channels._backfill_priority_key` / `_ordered_channels_for_phase` — sort backfill ascending by `(non_empty_month_count, channel_id)`. Phase 1 (current month) keeps natural order.
- `_channel_identity` extracted as a pure (no-mkdir) helper so the priority key derives the public path without filesystem side effects.

## Tests

- 2 new `count_nonempty_months` unit tests.
- 2 new `TestBackfillOrdering` tests (starved-first in backfill; order preserved in current phase).
- Full gate green locally: ruff lint, ruff format, mypy, 163 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)