### PR TITLE
feat: show leaf channel names, not full category paths, in navigation

### DIFF
--- a/scripts/generate_navigation.py
+++ b/scripts/generate_navigation.py
@@ -374,10 +374,18 @@ def _is_thread_path(p: str, path_set: set[str]) -> bool:
 
 
 def _build_channel_entry(name: str, raw_archives: list[dict]) -> dict:
-    """Build a channel/thread stats dict from its raw per-month archives."""
+    """Build a channel/thread stats dict from its raw per-month archives.
+
+    `name` is the full export path (e.g. "Information/general") and is the
+    URL key. `display_name` is the leaf segment shown in the UI ("general")
+    and `category` is the parent path ("Information", or "" when top-level)
+    so templates don't render the category prefix into the channel title.
+    """
     archives, archive_count, total = _finalize_archives(raw_archives)
     return {
         "name": name,
+        "display_name": name.split("/")[-1],
+        "category": _parent_path(name) or "",
         "archives": archives,
         "archive_count": archive_count,
         "message_count": archives[0]["message_count"] if archives else 0,
@@ -693,6 +701,9 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915  # Main orchestration functi
                 for thread in threads:
                     thread_view = {
                         "name": thread["path"],
+                        "display_name": thread["title"],
+                        "category": _parent_path(thread["path"]) or "",
+                        "is_thread": True,
                         "title": thread["title"],
                         "threads": [],
                     }

--- a/templates/channel_index.html.j2
+++ b/templates/channel_index.html.j2
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>#{{ channel.name }} Archive - {{ server.display_name }}</title>
+    <title>{% if channel.is_thread %}🧵 {% else %}#{% endif %}{{ channel.display_name or channel.name }} Archive - {{ server.display_name }}</title>
     <link rel="stylesheet" href="/assets/style.css">
 </head>
 <body>
@@ -11,9 +11,10 @@
         <nav class="breadcrumb">
             <a href="/index.html">Home</a> &gt;
             <a href="/{{ server.name }}/index.html">{{ server.display_name }}</a> &gt;
-            <span>#{{ channel.name }}</span>
+            {% if channel.category %}<span>{{ channel.category }}</span> &gt;{% endif %}
+            <span>{% if channel.is_thread %}🧵 {% else %}#{% endif %}{{ channel.display_name or channel.name }}</span>
         </nav>
-        <h1>#{{ channel.name }} Archive</h1>
+        <h1>{% if channel.is_thread %}🧵 {% else %}#{% endif %}{{ channel.display_name or channel.name }} Archive</h1>
     </header>
 
     <main>

--- a/templates/server_index.html.j2
+++ b/templates/server_index.html.j2
@@ -20,7 +20,8 @@
             <h2>Channels</h2>
             {% for channel in channels %}
             <div class="channel-card">
-                <h3><a href="/{{ server.name }}/{{ channel.name }}/index.html">{% if channel.is_forum %}📋 {% else %}#{% endif %}{{ channel.name }}</a></h3>
+                <h3><a href="/{{ server.name }}/{{ channel.name }}/index.html">{% if channel.is_forum %}📋 {% else %}#{% endif %}{{ channel.display_name or channel.name }}</a></h3>
+                {% if channel.category %}<p class="category">in {{ channel.category }}</p>{% endif %}
                 {% if channel.is_forum %}
                 <p class="stats">Forum with discussion threads</p>
                 <p><a href="/{{ server.name }}/{{ channel.name }}/index.html">View all threads →</a></p>

--- a/tests/test_generate_navigation_main.py
+++ b/tests/test_generate_navigation_main.py
@@ -278,6 +278,45 @@ def test_organize_data_channel_without_threads_has_empty_thread_list() -> None:
         assert chan["total_messages"] == 3  # noqa: PLR2004
 
 
+def test_organize_data_channel_display_name_is_leaf_not_full_path() -> None:
+    """A channel nested under a category keeps the full path as its URL key
+    (`name`) but exposes a `display_name` of just the leaf segment and a
+    `category` of the parent. Without this the UI renders "#Information/general"
+    instead of "#general"."""
+    exports = [
+        {
+            "server": "wafer-space",
+            "channel": "Information/general",
+            "date": "2026-04",
+            "path": "wafer-space/Information/general/2026-04/2026-04.html",
+        },
+        {
+            "server": "wafer-space",
+            "channel": "welcome",
+            "date": "2026-04",
+            "path": "wafer-space/welcome/2026-04/2026-04.html",
+        },
+    ]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        public_dir = Path(tmpdir) / "public"
+        public_dir.mkdir()
+        _write_json(
+            public_dir, "wafer-space/Information/general/2026-04/2026-04.json", "general", 2
+        )
+        _write_json(public_dir, "wafer-space/welcome/2026-04/2026-04.json", "welcome", 1)
+
+        channels = organize_data(exports, public_dir)["wafer-space"]["channels"]
+
+        nested = channels["Information/general"]
+        assert nested["name"] == "Information/general"  # URL key keeps full path
+        assert nested["display_name"] == "general"  # what the UI shows
+        assert nested["category"] == "Information"
+
+        top = channels["welcome"]
+        assert top["display_name"] == "welcome"
+        assert top["category"] == ""
+
+
 def test_organize_data_handles_empty_exports() -> None:
     """Test that organize_data handles empty exports list"""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Problem

Channels nested under a Discord category used their full export path (e.g. `Information/general`) as **both** the URL key and the display text, so the site rendered "**#Information/general**" in channel cards, breadcrumbs, and page titles — ugly and confusing.

## Fix

Separate display from URL:
- Channel/thread entries now carry `display_name` (leaf, e.g. `general`) and `category` (parent path, e.g. `Information`) alongside the full-path `name` used for URLs.
- Templates render the leaf with a `#` (channel) or 🧵 (thread) prefix, show the category as a subtle label and breadcrumb segment, and fall back to `name` if `display_name` is absent.
- Thread index pages now title themselves with the human thread title + 🧵 marker instead of the raw path.

## Verification

End-to-end (`tmp/e2e_nav.py`): server cards show "#announcements / in Information", breadcrumb is `Home > Server > Information > #announcements`, and the thread page H1 is "🧵 Can one join even if I wasn't part of?". New unit test `test_organize_data_channel_display_name_is_leaf_not_full_path`. Full gate green (ruff, format, mypy, 164 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)