### PR TITLE
fix: emit version-controlled stylesheet so CSS changes actually deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ build/
 # Exports (temporary storage)
 exports/
 
+# Generated static site — built by the pipeline and published to gh-pages,
+# never committed to master. The canonical stylesheet source lives in assets/.
+public/
+
 # Local scratch directory (per-project conventions)
 tmp/
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -90,6 +90,15 @@ main {
     margin: 0.25rem 0;
 }
 
+/* Category label under a channel/thread heading (e.g. "in Information"). */
+.category {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    margin: 0.1rem 0 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
 .formats {
     margin-top: 0.75rem;
     color: var(--text-secondary);
@@ -165,6 +174,17 @@ footer a:hover {
     color: var(--text-secondary);
     font-size: 1.1rem;
     margin-top: 0.5rem;
+}
+
+/* Threads-in-channel section: a labelled group above the thread cards. */
+.thread-list {
+    margin-top: 2.5rem;
+}
+
+.thread-list > h2 {
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--bg-tertiary);
 }
 
 .thread-card {

--- a/scripts/generate_navigation.py
+++ b/scripts/generate_navigation.py
@@ -2,6 +2,7 @@
 """Generate navigation index pages from exported logs."""
 
 import json
+import shutil
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -15,6 +16,10 @@ from jinja2 import Environment, FileSystemLoader
 MIN_PATH_PARTS_FOR_CHANNEL = 3
 MIN_PATH_PARTS_FOR_EXPORT = 4  # server, channel, month, file
 YYYY_MM_FORMAT_LENGTH = 7  # Length of "YYYY-MM" date format
+
+# The version-controlled static assets (site stylesheet) live OUTSIDE public/
+# so they survive the deploy workflow's `rm -rf public` + gh-pages checkout.
+ASSETS_SOURCE_DIR = Path(__file__).resolve().parent.parent / "assets"
 
 
 @dataclass
@@ -237,6 +242,33 @@ def get_forum_channels(  # noqa: C901  # Complexity needed for directory type de
             # But only include if it's in state.json (don't auto-detect new forums)
 
     return forum_names
+
+
+def copy_static_assets(public_dir: Path) -> None:
+    """Emit the version-controlled stylesheet into `public_dir/assets/`.
+
+    The deploy workflow runs `rm -rf public` and then checks out the existing
+    gh-pages branch into `public/`, so a stylesheet committed *under* public/
+    never survives to the deploy. We keep the canonical copy in the repo's
+    top-level `assets/` (outside public/) and emit it here — navigation runs
+    after the gh-pages checkout and before the deploy, so this guarantees the
+    version-controlled CSS ships every run.
+
+    A failure to copy must NEVER abort navigation (and therefore the deploy);
+    the worst acceptable outcome is the previously-deployed stylesheet
+    remaining in place. So all errors are swallowed with a warning.
+    """
+    try:
+        src = ASSETS_SOURCE_DIR / "style.css"
+        if not src.exists():
+            print(f"  ⚠ No stylesheet source at {src}; leaving existing assets in place.")
+            return
+        dest_dir = public_dir / "assets"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest_dir / "style.css")
+        print(f"  ✓ Emitted stylesheet to {dest_dir / 'style.css'}")
+    except OSError as e:
+        print(f"  ⚠ Could not emit static assets ({e}); leaving existing assets in place.")
 
 
 def generate_site_index(config: dict, servers: list[dict], output_path: Path) -> None:
@@ -650,6 +682,10 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915  # Main orchestration functi
 
         # Organize data by server and channel
         servers_data = organize_data(exports, public_dir)
+
+        # Emit the version-controlled stylesheet (see copy_static_assets for
+        # why this can't just be committed under public/).
+        copy_static_assets(public_dir)
 
         # Generate site index
         print("Generating site index...")

--- a/tests/test_generate_navigation_main.py
+++ b/tests/test_generate_navigation_main.py
@@ -317,6 +317,41 @@ def test_organize_data_channel_display_name_is_leaf_not_full_path() -> None:
         assert top["category"] == ""
 
 
+def test_copy_static_assets_emits_versioned_stylesheet() -> None:
+    """copy_static_assets writes the version-controlled stylesheet into
+    public/assets/. The deploy does `rm -rf public` then checks out gh-pages,
+    so a stylesheet committed under public/ never ships; emitting it from a
+    source outside public/ during the build is what gets it deployed. The
+    emitted CSS must include the rules for the navigation's own classes."""
+    from scripts.generate_navigation import copy_static_assets
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        public_dir = Path(tmpdir) / "public"
+        public_dir.mkdir()
+
+        copy_static_assets(public_dir)
+
+        css = public_dir / "assets" / "style.css"
+        assert css.exists()
+        text = css.read_text()
+        assert ".category" in text
+        assert ".thread-list" in text
+
+
+def test_copy_static_assets_never_raises_when_dest_unwritable(tmp_path: Path) -> None:
+    """A copy failure must NOT abort navigation/deploy — it is swallowed.
+
+    We point public_dir at a path whose `assets` is a regular file, so mkdir
+    fails; the function must warn and return rather than raise."""
+    from scripts.generate_navigation import copy_static_assets
+
+    public_dir = tmp_path / "public"
+    public_dir.mkdir()
+    (public_dir / "assets").write_text("not a directory")  # blocks mkdir
+
+    copy_static_assets(public_dir)  # must not raise
+
+
 def test_organize_data_handles_empty_exports() -> None:
     """Test that organize_data handles empty exports list"""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Problem

The deploy workflow runs `rm -rf public` then checks out gh-pages into `public/`. So `public/assets/style.css` (committed in master) was **deleted every run** and the live CSS came solely from whatever already sat on gh-pages. Editing the tracked stylesheet had **zero effect** on the site — a silent footgun, and the reason the newly-added `.category` / `.thread-list` classes had no styling.

## Fix

- Move the canonical stylesheet to top-level `assets/` (outside `public/`, so it survives the `rm`).
- `generate_navigation.copy_static_assets()` emits it into `public/assets/` during the build — which runs **after** the gh-pages checkout and **before** the deploy — guaranteeing the version-controlled CSS ships every run.
- Best-effort copy: any failure is swallowed with a warning, so it can never abort navigation or block the deploy (no `continue-on-error` / `|| true` needed).
- Add the missing `.category` and `.thread-list` rules.
- Gitignore `public/` — it is generated and published to gh-pages, never committed (matches CLAUDE.md).

## Verification

End-to-end (`tmp/e2e_nav.py`): navigate emits `public/assets/style.css` (4078B, was 3596B) containing both new rules; nesting/display assertions still PASS. Two new unit tests (emits stylesheet; never raises on copy failure). Full gate green: ruff, format, mypy, 166 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)