### PR TITLE
fix: nest threads under FORUM channels, not just channels with own exports

### DIFF
--- a/scripts/generate_navigation.py
+++ b/scripts/generate_navigation.py
@@ -399,10 +399,40 @@ def _parent_path(p: str) -> str | None:
     return p.rsplit("/", 1)[0] if "/" in p else None
 
 
-def _is_thread_path(p: str, path_set: set[str]) -> bool:
-    """A path is a thread iff its parent path is itself an exported path."""
-    parent = _parent_path(p)
-    return parent is not None and parent in path_set
+def _category_paths(leaf_paths: set[str]) -> set[str]:
+    """Return the depth-1 prefixes that are categories (not channels/threads).
+
+    Discord categories are organizational containers: they never hold
+    messages, so they never have a month export of their own. Structurally
+    that means a top-level (single-segment) path that is a *prefix* of some
+    exported leaf but is NOT itself an exported leaf. Decoding this lets us
+    tell "Category/channel" apart from "forum/thread" without an API call.
+    """
+    categories: set[str] = set()
+    for p in leaf_paths:
+        first = p.split("/", 1)[0]
+        if "/" in p and first not in leaf_paths:
+            categories.add(first)
+    return categories
+
+
+def _channel_level_path(leaf: str, categories: set[str]) -> str:
+    """Return the channel/forum portion of an exported `leaf` path.
+
+    Strips a leading category segment, then the channel/forum is the first
+    remaining segment (under a category that's `category/channel`). Anything
+    deeper than the channel/forum is a thread; this returns just the
+    channel/forum prefix, which is the nav entry the thread belongs to.
+
+    Examples (with categories = {"Information"}):
+      Information/general                     -> Information/general   (channel)
+      Information/questions                   -> Information/questions (forum)
+      Information/questions/antenna-error     -> Information/questions (thread's forum)
+      welcome                                 -> welcome              (uncategorized channel)
+    """
+    segs = leaf.split("/")
+    keep = 2 if segs[0] in categories else 1
+    return "/".join(segs[:keep])
 
 
 def _build_channel_entry(name: str, raw_archives: list[dict]) -> dict:
@@ -428,10 +458,12 @@ def _build_channel_entry(name: str, raw_archives: list[dict]) -> dict:
 def organize_data(exports: list[dict], public_dir: Path) -> dict:
     """Organize exports into servers → channels, with threads nested.
 
-    A path is a THREAD when its parent path is *also* an exported path
-    (i.e., the parent is itself a channel with its own month exports).
-    Threads are nested under their parent channel's `threads` list rather
-    than listed as top-level channels. Everything else is a CHANNEL.
+    Classification is by category-aware depth (see `_category_paths` /
+    `_channel_level_path`): a leaf path resolves to a channel/forum level,
+    and anything deeper than that level is a THREAD nested under it.
+    Crucially this nests threads under FORUM channels too — a forum has no
+    month export of its own, so we SYNTHESIZE its entry from its threads
+    rather than dropping the threads in as top-level channels.
 
     Each channel dict gains: `archives`, `archive_count`, `message_count`
     (newest archive), `total_messages` (sum across months), and `threads`
@@ -454,6 +486,7 @@ def organize_data(exports: list[dict], public_dir: Path) -> dict:
     servers_data: dict[str, Any] = {}
     for server, paths in raw.items():
         path_set = set(paths)
+        categories = _category_paths(path_set)
         server_data: dict[str, Any] = {
             "name": server,
             "display_name": server.replace("-", " ").title(),
@@ -461,18 +494,20 @@ def organize_data(exports: list[dict], public_dir: Path) -> dict:
             "last_updated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
         }
 
-        # Real channels first (a path whose parent is NOT an exported path).
-        for path in paths:
-            if _is_thread_path(path, path_set):
-                continue
-            entry = _build_channel_entry(path, paths[path]["archives"])
+        # Top-level entries = every distinct channel/forum level. A forum has
+        # no export of its own, so its entry is synthesized with empty
+        # archives; a regular channel reuses its own exported archives.
+        for cpath in {_channel_level_path(p, categories) for p in paths}:
+            raw_archives = paths[cpath]["archives"] if cpath in paths else []
+            entry = _build_channel_entry(cpath, raw_archives)
             entry["threads"] = []
-            server_data["channels"][path] = entry
+            server_data["channels"][cpath] = entry
 
-        # Attach threads to their parent channel.
+        # Anything deeper than its channel level is a thread; nest it.
         for path in paths:
-            if not _is_thread_path(path, path_set):
-                continue
+            cpath = _channel_level_path(path, categories)
+            if path == cpath:
+                continue  # this leaf IS the channel/forum, not a thread
             entry = _build_channel_entry(path, paths[path]["archives"])
             newest_date = entry["archives"][0]["date"] if entry["archives"] else ""
             thread = {
@@ -482,9 +517,7 @@ def organize_data(exports: list[dict], public_dir: Path) -> dict:
                 "title": _read_channel_title(public_dir, server, path, newest_date),
                 "last_activity": newest_date,
             }
-            parent_chan = server_data["channels"].get(_parent_path(path))
-            if parent_chan is not None:
-                parent_chan["threads"].append(thread)
+            server_data["channels"][cpath]["threads"].append(thread)
 
         # Sort each channel's threads newest-activity first.
         for chan in server_data["channels"].values():

--- a/tests/test_generate_navigation_main.py
+++ b/tests/test_generate_navigation_main.py
@@ -257,6 +257,76 @@ def test_organize_data_nests_threads_under_parent_channel() -> None:
         assert thread["archives"][0]["date"] == "2026-04"
 
 
+def test_organize_data_nests_threads_under_forum_with_no_own_export() -> None:
+    """A FORUM channel has no month export of its own — only its threads do.
+
+    This is the real-data case that the parent-must-be-an-exported-path rule
+    missed: `Information/questions` (a forum) has zero direct exports, so its
+    68 threads were wrongly rendered as top-level channels. The forum entry
+    must be SYNTHESIZED so threads nest under it, and the forum itself must
+    never appear nested as a thread, nor the category as a channel.
+    """
+    exports = [
+        {
+            "server": "wafer-space",
+            "channel": "Information/general",
+            "date": "2026-04",
+            "path": "wafer-space/Information/general/2026-04/2026-04.html",
+        },
+        {
+            "server": "wafer-space",
+            "channel": "Information/questions/antenna-error",
+            "date": "2026-04",
+            "path": "wafer-space/Information/questions/antenna-error/2026-04/2026-04.html",
+        },
+        {
+            "server": "wafer-space",
+            "channel": "Information/questions/cadence-pdk",
+            "date": "2026-03",
+            "path": "wafer-space/Information/questions/cadence-pdk/2026-03/2026-03.html",
+        },
+    ]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        public_dir = Path(tmpdir) / "public"
+        public_dir.mkdir()
+        _write_json(
+            public_dir, "wafer-space/Information/general/2026-04/2026-04.json", "general", 5
+        )
+        _write_json(
+            public_dir,
+            "wafer-space/Information/questions/antenna-error/2026-04/2026-04.json",
+            "Antenna error on M3",
+            9,
+        )
+        _write_json(
+            public_dir,
+            "wafer-space/Information/questions/cadence-pdk/2026-03/2026-03.json",
+            "Cadence PDK access",
+            4,
+        )
+
+        servers_data = organize_data(exports, public_dir)
+        channels = servers_data["wafer-space"]["channels"]
+
+        # The forum is a synthesized top-level entry; its threads are NOT.
+        assert "Information/questions" in channels
+        assert "Information/questions/antenna-error" not in channels
+        assert "Information/questions/cadence-pdk" not in channels
+        # The category itself is never a channel.
+        assert "Information" not in channels
+        # Real top-level entries: the regular channel + the forum (threads excluded).
+        assert servers_data["wafer-space"]["channel_count"] == EXPECTED_ARCHIVE_COUNT_TWO
+
+        forum = channels["Information/questions"]
+        assert forum["total_messages"] == 0  # forum has no messages of its own
+        assert forum["display_name"] == "questions"
+        assert forum["category"] == "Information"
+        assert {t["name"] for t in forum["threads"]} == {"antenna-error", "cadence-pdk"}
+        # Threads keep their human titles and nest with their own message counts.
+        titles = {t["title"] for t in forum["threads"]}
+        assert titles == {"Antenna error on M3", "Cadence PDK access"}
+
+
 def test_organize_data_channel_without_threads_has_empty_thread_list() -> None:
     """A plain channel (no nested threads) still exposes an empty threads list."""
     exports = [

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -31,9 +31,11 @@ def test_channel_index_template_exists() -> None:
 
 
 def test_css_file_exists() -> None:
-    """Test that style.css exists"""
-    css_path = Path("public/assets/style.css")
-    assert css_path.exists(), "style.css should exist"
+    """The canonical stylesheet lives in version control at assets/style.css
+    (outside public/, which is generated). generate_navigation emits it into
+    public/assets/ at build time — see copy_static_assets."""
+    css_path = Path("assets/style.css")
+    assert css_path.exists(), "assets/style.css should exist"
 
 
 def test_site_index_template_renders() -> None:
@@ -111,7 +113,7 @@ def test_channel_index_template_renders() -> None:
 
 def test_css_contains_discord_theme() -> None:
     """Test that CSS contains Discord-themed colors"""
-    css_path = Path("public/assets/style.css")
+    css_path = Path("assets/style.css")
     css_content = css_path.read_text()
 
     # Check for Discord dark theme colors


### PR DESCRIPTION
## Problem (the bug was only half-fixed)

The earlier nesting fix classified a path as a thread only when its **parent was itself an exported path**. That works for a regular channel that has its own messages *and* threads (e.g. `#announcements`), but **fails for forum channels**: a forum holds no messages of its own, so it has no month export and never appears in the exported-path set. Result — every forum thread (all 68 under `Information/questions`, ~197 of 214 entries) still rendered as a **top-level channel**. This is precisely the "threads appearing as their own channel" bug the report described.

## Fix — classify by category-aware depth

- `_category_paths()`: a depth-1 prefix that is **not** itself an exported leaf is a Discord category (categories never hold messages → never export).
- `_channel_level_path()`: strip a leading category; the channel/forum is the next segment; anything deeper is a thread belonging to it.
- `organize_data()`: build a top-level entry for every distinct channel/forum level — **synthesizing forum entries** (empty archives) when a forum has no export of its own — then nest each deeper leaf as a thread.

## Validation against the live tree (214 paths)

4 categories, **19 channel/forum entries (was wrongly 86), 197 threads (was wrongly 128)**, zero misclassifications. `Information/questions` is synthesized with its 68 threads nested; channels-with-threads (`announcements`, `cob`) still work.

Full gate green: ruff, format, mypy, 167 tests; e2e PASS. (Also updates two tests that referenced the old `public/assets/style.css` path to the new `assets/style.css` source.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)