### PR TITLE
fix: deploy gh-pages before committing state.json (unblock frozen live site)

### DIFF
--- a/.github/workflows/export-and-publish.yml
+++ b/.github/workflows/export-and-publish.yml
@@ -135,6 +135,24 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
+      # Publish the site BEFORE mutating master. Deploying gh-pages must not
+      # depend on the state.json commit succeeding — the commit step rebases
+      # onto master and has historically failed (rebase/autostash/editor),
+      # which, when it ran first, skipped the deploy and froze the live site
+      # for days. Same principle the LFS-preserve step already follows: do the
+      # user-visible publish first, then the best-effort master bookkeeping.
+      - name: Deploy to GitHub Pages
+        if: steps.check_changes.outputs.has_changes == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages
+          user_name: 'Discord Archive Bot'
+          user_email: 'actions@github.com'
+          commit_message: 'chore: deploy updated logs'
+        id: deploy
+
       - name: Commit state.json to main
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |
@@ -177,18 +195,6 @@ jobs:
           else
             echo "No changes to state.json, skipping commit"
           fi
-
-      - name: Deploy to GitHub Pages
-        if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
-          publish_branch: gh-pages
-          user_name: 'Discord Archive Bot'
-          user_email: 'actions@github.com'
-          commit_message: 'chore: deploy updated logs'
-        id: deploy
 
       # Preserve the held-back oversized media in Git LFS on master so the bytes
       # survive even if Discord's CDN copy expires. This runs AFTER the deploy


### PR DESCRIPTION
## Root cause of the frozen live site

The Export-and-Publish workflow has failed **6 days running** (05-26 → 05-27) — every failure at the **"Commit state.json to main"** step (rebase onto master: autostash/editor/conflict issues, patched iteratively). Because that step ran *before* "Deploy to GitHub Pages", each failure **skipped the deploy** and `discord.wafer.space` never updated — even though export → organize → navigate all succeeded. This is why merged fixes weren't reaching the live site.

## Fix

Reorder: **Deploy to GitHub Pages → then Commit state.json → then Preserve LFS.** The deploy only needs `public/` (ready after navigate + hold-back-oversized-media), not master state. This applies the exact principle the LFS-preserve step already documents ("runs AFTER the deploy on purpose … can never block the deploy"): publish the user-visible site first, then best-effort master bookkeeping.

If the state.json commit still fails, the job goes red **honestly** (no `continue-on-error`/`|| true`), but the site is already published — decoupled from the flaky step.

## Effect

The next run that executes (the queued all-fixes run on `a7f11f661`, or this PR's merge run) will deploy the correct site — forum-thread nesting, leaf names, category labels, stylesheet — regardless of whether the state.json commit succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)