### PR TITLE
fix: ISO dates and bounded month range in DCE exports (#3, #4)

### DIFF
--- a/scripts/export_channels.py
+++ b/scripts/export_channels.py
@@ -203,9 +203,12 @@ def _export_one_month(
     Returns (exports_completed, failures, errors).
     """
     after, before_bound = month_bounds(month)
-    # For the current month we omit --before so newly-arrived messages are
-    # included (DCE captures everything from `after` up to its API "now").
-    before: str | None = None if is_current_month else before_bound
+    # Always bracket with --before, including the current month. before_bound is
+    # the next month's first instant UTC, and no current-month message can
+    # exceed it, so nothing is lost — but DCE's header now renders a bounded
+    # date range instead of an open-ended "After ..." that reads as the prior
+    # day's 23:59 (issue #4).
+    before: str = before_bound
 
     media_dir_path = channel_export_dir / f"{month}_media"
     download_media = context.config["export"].get("download_media", False)
@@ -655,6 +658,7 @@ def format_export_command(  # noqa: PLR0913
     after_timestamp: str | None = None,
     media_config: MediaConfig | None = None,
     before_timestamp: str | None = None,
+    locale: str = "en-CA",
 ) -> list[str]:
     """Format DiscordChatExporter CLI command.
 
@@ -667,6 +671,10 @@ def format_export_command(  # noqa: PLR0913
         media_config: Media download configuration
         before_timestamp: Optional upper-bound timestamp; paired with
             after_timestamp to bracket a single calendar month
+        locale: Locale DCE uses to format dates/numbers. Defaults to "en-CA",
+            whose short-date pattern is ISO YYYY-MM-DD — DCE's own default is
+            US "MM/dd/yyyy", and its `--dateformat` flag is a documented no-op,
+            so `--locale` is the only lever for date formatting.
 
     Returns:
         Command as list of arguments
@@ -697,6 +705,8 @@ def format_export_command(  # noqa: PLR0913
         format_type,
         "-o",
         output_path,
+        "--locale",
+        locale,
     ]
 
     if after_timestamp:

--- a/tests/test_export_channels.py
+++ b/tests/test_export_channels.py
@@ -1,10 +1,15 @@
 # tests/test_export_channels.py
 import os
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
 from scripts.export_channels import (
+    ChannelExportContext,
+    ChannelInfo,
     MediaConfig,
+    _export_one_month,
     _is_permission_error,
     format_export_command,
     get_bot_token,
@@ -104,6 +109,8 @@ def test_format_export_command() -> None:
         "HtmlDark",
         "-o",
         "exports/test.html",
+        "--locale",
+        "en-CA",
     ]
 
     assert cmd == expected
@@ -121,6 +128,49 @@ def test_format_export_command_with_after() -> None:
 
     assert "--after" in cmd
     assert "2025-01-15T14:00:00Z" in cmd
+
+
+def test_format_export_command_includes_iso_locale() -> None:
+    """Every export must pass --locale so DCE formats dates ISO (en-CA →
+    YYYY-MM-DD), not the US default MM/dd/yyyy (issue #3)."""
+    cmd = format_export_command(
+        token="test_token",
+        channel_id="123456",
+        output_path="exports/test.html",
+        format_type="HtmlDark",
+        after_timestamp=None,
+    )
+    assert "--locale" in cmd
+    locale_value = cmd[cmd.index("--locale") + 1]
+    assert locale_value == "en-CA"
+
+
+def test_export_one_month_current_month_is_bounded(tmp_path: Path) -> None:
+    """The current month must be bracketed with --before too, so DCE renders a
+    bounded date range instead of an open-ended 'After ...' that reads as the
+    prior day (issue #4). before-bound is the next month's first instant UTC."""
+    captured: list[list[str]] = []
+
+    def _capture(cmd: list[str], *args: object, **kwargs: object) -> tuple[bool, str]:
+        captured.append(cmd)
+        return True, "ok"
+
+    context = ChannelExportContext(
+        config={"export": {"formats": ["html"]}},
+        token="test_token",
+        server_key="wafer-space",
+        state_manager=Mock(),
+    )
+    channel_info = ChannelInfo(
+        channel_id="123456", channel_name="general", safe_name="general", forum_name=""
+    )
+    with patch("scripts.export_channels.run_export", side_effect=_capture):
+        _export_one_month(context, channel_info, tmp_path, "2026-06", is_current_month=True)
+
+    assert captured, "expected at least one export command"
+    cmd = captured[0]
+    assert "--before" in cmd, "current month must be bracketed with --before"
+    assert "2026-07-01T00:00:00+00:00" in cmd
 
 
 def test_format_export_command_invalid_format() -> None:

--- a/tests/test_export_orchestration.py
+++ b/tests/test_export_orchestration.py
@@ -364,13 +364,18 @@ commit_author = "Test Bot"
                                     assert mock_format.call_count == EXPECTED_MONTHS_TWO
 
                                     # Current month (February) is processed FIRST,
-                                    # with --after at the January boundary and no
-                                    # --before so it captures messages up to "now".
+                                    # with --after at the January boundary and
+                                    # --before at the March boundary so DCE renders
+                                    # a bounded date range (issue #4) — no
+                                    # current-month message can exceed next-month
+                                    # start, so nothing is lost.
                                     feb_call = mock_format.call_args_list[0]
                                     assert feb_call.kwargs["after_timestamp"].startswith(
                                         "2026-01-31"
                                     )
-                                    assert feb_call.kwargs["before_timestamp"] is None
+                                    assert feb_call.kwargs["before_timestamp"].startswith(
+                                        "2026-03-01"
+                                    )
 
                                     # January backfill comes after, fully bracketed.
                                     jan_call = mock_format.call_args_list[1]
@@ -503,9 +508,13 @@ commit_author = "Test Bot"
         observed_months: list[str] = []
 
         def fake_format(**kwargs: object) -> list[str]:
-            before = kwargs.get("before_timestamp")
-            # Current month = the call with no --before (open-ended).
-            observed_months.append("current" if before is None else "backfill")
+            after = kwargs.get("after_timestamp")
+            # Both phases now pass --before (issue #4), so distinguish by the
+            # --after bound instead: the current month (Feb 2026) starts just
+            # after 2026-01-31; the backfill months (Dec 2025, Jan 2026) start
+            # earlier.
+            is_current = isinstance(after, str) and after.startswith("2026-01-31")
+            observed_months.append("current" if is_current else "backfill")
             return ["dce", "stub"]
 
         with fixed_months("2025-12", "2026-02"):
@@ -900,13 +909,18 @@ commit_author = "Test Bot"
                                     ]
                                     assert len(thread_calls) == 1
                                     # Current month bracket: --after just before
-                                    # 2026-02-01, --before is None (capture up to "now").
+                                    # 2026-02-01, --before at 2026-03-01 so DCE
+                                    # renders a bounded date range (issue #4).
                                     assert (
                                         thread_calls[0]
                                         .kwargs["after_timestamp"]
                                         .startswith("2026-01-31")
                                     )
-                                    assert thread_calls[0].kwargs["before_timestamp"] is None
+                                    assert (
+                                        thread_calls[0]
+                                        .kwargs["before_timestamp"]
+                                        .startswith("2026-03-01")
+                                    )
 
         del os.environ["DISCORD_BOT_TOKEN"]
 


### PR DESCRIPTION
Fixes two date-correctness defects on the published archive (reported by the owner).

## #3 — American dates
Message timestamps and headers rendered US-style (`05/31/2026 23:59`, `Jason Yang 06/01/2026 18:39`). Root cause: `format_export_command()` passed no `--locale`, so DCE used its US default (`MM/dd/yyyy`). DCE's `--dateformat` is a documented no-op, so `--locale` is the only lever.

**Fix:** pass `--locale en-CA` (short-date pattern is ISO `YYYY-MM-DD`, which the owner prefers).

## #4 — "After 2026-05-31" is not a range
Current-month pages showed an open-ended `After 05/31/2026 23:59` with no upper bound (and the bound read as the *prior* day). Root cause: `_export_one_month` dropped `--before` for the current month.

**Fix:** bracket the current month with `--before = next-month UTC start` too. Nothing is lost (no current-month message can exceed next-month start), but DCE's header now renders a bounded range.

## Tests
- New: `--locale en-CA` present in the command; current-month export is bracketed with `--before`.
- Updated three orchestration tests that asserted the old `before is None` current-month behavior (re-keyed the phase-ordering heuristic on `--after`).
- Full suite: 169 passed; ruff/format/mypy clean.

Part of the 5-fix archive-correctness series; this is PR 1/4 (dates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)