### PR TITLE
fix: heal JSON↔HTML message divergence; latest export authoritative (#1)

### DIFF
--- a/scripts/export_channels.py
+++ b/scripts/export_channels.py
@@ -14,6 +14,7 @@ from typing import Any
 from scripts.channel_classifier import ChannelType, classify_channel, sanitize_thread_name
 from scripts.config import load_config
 from scripts.months import (
+    count_divergent_months,
     count_nonempty_months,
     current_month_utc,
     month_bounds,
@@ -365,25 +366,31 @@ def _backfill_priority_key(
     server_key: str,
     channel_path_map: dict[str, str],
     public_dir: Path,
-) -> tuple[int, str]:
-    """Sort key for the backfill phase: starved entries first.
+) -> tuple[int, int, str]:
+    """Sort key for the backfill phase: heal-needed and starved entries first.
 
-    Returns (non_empty_month_count, channel_id). Sorting ascending puts
-    channels/threads with the LEAST real data first, so threads showing
-    only an empty current-month export ("empty threads" the user sees)
-    get their historical months backfilled before time is spent on
-    already-rich channels. Within a tie, sort by channel id for stable
-    ordering across runs.
+    Returns (divergent_rank, non_empty_month_count, channel_id), sorted
+    ascending:
+
+      - divergent_rank is 0 for channels/threads with at least one month whose
+        JSON and HTML message counts disagree (issue #1 damage — e.g. a blank
+        page for a month with hundreds of messages), else 1. Damaged entries
+        re-export FIRST so the visible breakage heals fastest.
+      - within the same rank, the entry with the LEAST real data goes first, so
+        "empty threads" still get their history backfilled before already-rich
+        channels.
+      - channel id breaks ties for stable ordering across runs.
     """
     chan_id = channel.get("id") or ""
     if not chan_id:
-        return (0, chan_id)
+        return (1, 0, chan_id)
     try:
         safe_name, forum_name = _channel_identity(channel, channel_type, chan_id, channel_path_map)
     except Exception:  # noqa: BLE001 — never let sorting crash the run
-        return (0, chan_id)
+        return (1, 0, chan_id)
     pub = _public_channel_dir(public_dir, server_key, channel_type, safe_name, forum_name)
-    return (count_nonempty_months(pub), chan_id)
+    divergent_rank = 0 if count_divergent_months(pub) > 0 else 1
+    return (divergent_rank, count_nonempty_months(pub), chan_id)
 
 
 def _ordered_channels_for_phase(  # noqa: PLR0913  # needs full per-server context

--- a/scripts/months.py
+++ b/scripts/months.py
@@ -33,6 +33,12 @@ LAST_MONTH = 12
 # YYYY-MM matches a 4-digit year, hyphen, 2-digit month (01-12).
 _MONTH_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
 
+# DCE HtmlDark minifies attributes (no quotes), so each rendered message is
+# marked by `data-message-id=<snowflake>`. Counting these gives the number of
+# messages actually shown on the page, which we compare against the JSON's
+# message count to detect the issue-#1 JSON/HTML divergence.
+_HTML_MESSAGE_RE = re.compile(rb"data-message-id=(\d+)")
+
 
 def _parse_month(month: str) -> tuple[int, int]:
     """Parse a "YYYY-MM" string into (year, month) ints.
@@ -135,8 +141,14 @@ def scan_completed_months(channel_dir: Path) -> set[str]:
         if not html_file.exists() or html_file.stat().st_size == 0:
             continue
         json_file = entry / f"{entry.name}.json"
-        if json_file.exists() and not _json_is_month_pure(json_file, entry.name):
-            continue
+        if json_file.exists():
+            if not _json_is_month_pure(json_file, entry.name):
+                continue
+            # Complete only if the rendered HTML matches the JSON message count.
+            # When they disagree (issue #1: the JSON drifted above what the HTML
+            # renders), treat the month as incomplete so it re-exports and heals.
+            if not _month_is_consistent(json_file, html_file):
+                continue
         completed.add(entry.name)
     return completed
 
@@ -201,3 +213,59 @@ def _json_is_month_pure(json_file: Path, month: str) -> bool:
         if not isinstance(ts, str) or ts[:7] != month:
             return False
     return True
+
+
+def count_html_messages(html_file: Path) -> int:
+    """Count messages rendered in a DCE HtmlDark export.
+
+    Each message container carries `data-message-id=<snowflake>` (DCE minifies
+    attributes, so there are no quotes). Reading bytes keeps this fast on the
+    multi-MB HTML of a busy month.
+    """
+    try:
+        data = html_file.read_bytes()
+    except OSError:
+        return 0
+    return len(_HTML_MESSAGE_RE.findall(data))
+
+
+def _month_is_consistent(json_file: Path, html_file: Path) -> bool:
+    """True iff the JSON message count equals the count rendered in the HTML.
+
+    The published JSON drives the index/navigation message count; the HTML is
+    the page a reader sees. When they disagree (issue #1) the month must be
+    re-exported. Unreadable/malformed files return True so we don't force a
+    re-export we cannot reason about.
+    """
+    import json as _json
+
+    try:
+        with open(json_file, encoding="utf-8") as f:
+            json_count = len(_json.load(f).get("messages") or [])
+    except (OSError, _json.JSONDecodeError):
+        return True
+    return count_html_messages(html_file) == json_count
+
+
+def count_divergent_months(channel_dir: Path) -> int:
+    """Count months in `channel_dir` whose JSON and HTML message counts differ.
+
+    These are the issue-#1 damaged months (the JSON drifted above what the HTML
+    renders — e.g. a 758-message month showing a blank page). Used to rank
+    backfill priority so the visible damage heals before ordinary backfill.
+    """
+    if not channel_dir.exists() or not channel_dir.is_dir():
+        return 0
+    n = 0
+    for entry in channel_dir.iterdir():
+        if not entry.is_dir() or not is_month_dir_name(entry.name):
+            continue
+        json_file = entry / f"{entry.name}.json"
+        html_file = entry / f"{entry.name}.html"
+        if (
+            json_file.exists()
+            and html_file.exists()
+            and not _month_is_consistent(json_file, html_file)
+        ):
+            n += 1
+    return n

--- a/scripts/organize_exports.py
+++ b/scripts/organize_exports.py
@@ -33,68 +33,40 @@ from scripts.months import is_month_dir_name
 VALID_EXTENSIONS = {".html", ".txt", ".json", ".csv"}
 
 
-def _merge_json_exports(source_file: Path, dest_file: Path) -> bool:
-    """Merge new JSON export into the existing archive, deduplicating by ID.
-
-    Both source and destination are expected to belong to a single month
-    (encoded in the dest filename — `2026-05.json` means May 2026). We
-    discard any messages in the *existing* file whose timestamp is from
-    a different month: those are leftovers from the legacy current-month-
-    dump bug and would otherwise propagate forever through merges.
-
-    Within-month edits and deletions are preserved by ID-keyed merge, so
-    nothing legitimate is lost. DCE message IDs are snowflakes, which sort
-    chronologically, so we sort by integer ID at the end.
-    """
-    expected_month = dest_file.stem  # filename like "2026-05.json" → "2026-05"
+def _json_message_count(json_file: Path) -> int:
+    """Number of messages in a DCE JSON export (0 if missing/unreadable)."""
     try:
-        with open(source_file, encoding="utf-8") as f:
-            new_data = json.load(f)
+        with open(json_file, encoding="utf-8") as f:
+            return len(json.load(f).get("messages", []))
+    except (OSError, json.JSONDecodeError):
+        return 0
 
-        if not dest_file.exists():
-            with open(dest_file, "w", encoding="utf-8") as f:
-                json.dump(new_data, f, indent=2)
-            return True
 
-        with open(dest_file, encoding="utf-8") as f:
-            existing_data = json.load(f)
+def _accept_month_export(source_json: Path, dest_json: Path) -> tuple[bool, str | None]:
+    """Decide whether a freshly-exported month may replace the published one.
 
-        def _in_month(msg: dict[str, Any]) -> bool:
-            ts = msg.get("timestamp", "")
-            return isinstance(ts, str) and ts[:7] == expected_month
+    The latest *successful* export is authoritative: deletions propagate, so we
+    do NOT preserve published messages absent from the new export. (The old
+    by-ID union kept messages the latest HTML no longer rendered, which is what
+    desynced the index count from the page — issue #1.)
 
-        existing_messages = [m for m in existing_data.get("messages", []) if _in_month(m)]
-        new_messages = new_data.get("messages", [])
-
-        messages_by_id: dict[str, Any] = {}
-        for msg in existing_messages:
-            msg_id = msg.get("id")
-            if msg_id:
-                messages_by_id[msg_id] = msg
-        # New messages override existing entries with the same ID (edits).
-        for msg in new_messages:
-            msg_id = msg.get("id")
-            if msg_id:
-                messages_by_id[msg_id] = msg
-
-        sorted_messages = sorted(messages_by_id.values(), key=lambda m: int(m.get("id", 0)))
-
-        merged_data = new_data.copy()
-        merged_data["messages"] = sorted_messages
-        merged_data["messageCount"] = len(sorted_messages)
-
-        # Since we keep history across runs, the merged file represents the
-        # full month range, not the bracket of any single export.
-        merged_data["dateRange"] = {"after": None, "before": None}
-
-        with open(dest_file, "w", encoding="utf-8") as f:
-            json.dump(merged_data, f, indent=2)
-
-        return True
-
-    except Exception as e:
-        print(f"    ⚠ JSON merge failed for {source_file}: {e}")
-        return False
+    The single guard: a non-empty published month re-exporting to EMPTY is
+    almost certainly a transient/partial fetch — a channel does not lose a whole
+    month of messages to ordinary deletion in one run — so we keep the existing
+    export and surface an error instead of blanking the page.
+    """
+    if not source_json.exists() or not dest_json.exists():
+        return True, None
+    new_count = _json_message_count(source_json)
+    existing_count = _json_message_count(dest_json)
+    if new_count == 0 and existing_count > 0:
+        return (
+            False,
+            f"{source_json.name}: new export has 0 messages but the published month "
+            f"has {existing_count} — treating as a transient/partial fetch and keeping "
+            "the existing export (issue #1 transient guard)",
+        )
+    return True, None
 
 
 def _copy_media_directory(source_media_dir: Path, dest_media_dir: Path) -> bool:
@@ -105,19 +77,6 @@ def _copy_media_directory(source_media_dir: Path, dest_media_dir: Path) -> bool:
         if dest_media_dir.exists():
             shutil.rmtree(dest_media_dir)
         shutil.copytree(source_media_dir, dest_media_dir)
-        return True
-    except Exception:
-        return False
-
-
-def _copy_month_file(source_file: Path, dest_file: Path) -> bool:
-    """Copy a single per-month file, merging if JSON."""
-    extension = source_file.suffix
-    dest_file.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        if extension == ".json":
-            return _merge_json_exports(source_file, dest_file)
-        shutil.copy2(source_file, dest_file)
         return True
     except Exception:
         return False
@@ -219,12 +178,15 @@ def _walk_paths(top: Path) -> Iterator[tuple[Path, list[str], list[str]]]:
         stack.extend(dirs)
 
 
-def _organize_channel_directory(
+def _organize_channel_directory(  # noqa: C901  # per-month atomic publish is branchy
     channel_export_dir: Path,
     exports_root: Path,
     public_root: Path,
 ) -> tuple[int, list[str]]:
     """Move all per-month files in a channel directory into `public_root`.
+
+    Each month is published atomically: all of its formats come from the same
+    (latest) export, or none do — see `_accept_month_export`.
 
     Returns (files_organized, errors).
     """
@@ -235,20 +197,38 @@ def _organize_channel_directory(
     errors: list[str] = []
     months_touched: set[str] = set()
 
+    # Group this run's per-month files by month so each month publishes
+    # ATOMICALLY: all of its formats come from the same (latest) export, or none
+    # do. The old path merged JSON by ID while overwriting HTML wholesale, so a
+    # month's JSON count could drift above what the HTML rendered (issue #1).
+    by_month: dict[str, list[Path]] = {}
     for entry in sorted(channel_export_dir.iterdir()):
         if not entry.is_file():
             continue
-        stem = entry.stem
-        ext = entry.suffix
-        if ext not in VALID_EXTENSIONS or not is_month_dir_name(stem):
+        if entry.suffix not in VALID_EXTENSIONS or not is_month_dir_name(entry.stem):
             continue
-        dest_file = public_channel_dir / stem / f"{stem}{ext}"
-        if _copy_month_file(entry, dest_file):
-            files_organized += 1
-            months_touched.add(stem)
-            print(f"  ✓ {relative}/{entry.name} → {dest_file.relative_to(public_root)}")
-        else:
-            errors.append(f"Failed to copy {entry}")
+        by_month.setdefault(entry.stem, []).append(entry)
+
+    for month, files in sorted(by_month.items()):
+        dest_month_dir = public_channel_dir / month
+        accept, err = _accept_month_export(
+            channel_export_dir / f"{month}.json", dest_month_dir / f"{month}.json"
+        )
+        if not accept:
+            if err:
+                errors.append(err)
+                print(f"  ⚠ {relative}/{month}: {err}")
+            continue
+        dest_month_dir.mkdir(parents=True, exist_ok=True)
+        for src in files:
+            dest_file = dest_month_dir / src.name
+            try:
+                shutil.copy2(src, dest_file)
+                files_organized += 1
+                months_touched.add(month)
+                print(f"  ✓ {relative}/{src.name} → {dest_file.relative_to(public_root)}")
+            except OSError:
+                errors.append(f"Failed to copy {src}")
 
     # Per-month media directories sit alongside the per-month files
     for month in months_touched:

--- a/tests/test_months.py
+++ b/tests/test_months.py
@@ -204,10 +204,12 @@ def test_scan_completed_months_skips_cross_month_jsons(tmp_path: Path) -> None:
         )
     )
 
-    # A correctly-partitioned month next to it
+    # A correctly-partitioned month next to it. The HTML must render the same
+    # one message the JSON holds (data-message-id) so the consistency gate
+    # counts it as complete.
     pure_month = channel_dir / "2026-05"
     pure_month.mkdir()
-    (pure_month / "2026-05.html").write_text("<html>clean</html>")
+    (pure_month / "2026-05.html").write_text("<html><div data-message-id=10>hi</div></html>")
     (pure_month / "2026-05.json").write_text(
         _json.dumps({"messages": [{"id": "10", "timestamp": "2026-05-02T00:00:00+00:00"}]})
     )
@@ -215,6 +217,66 @@ def test_scan_completed_months_skips_cross_month_jsons(tmp_path: Path) -> None:
     completed = scan_completed_months(channel_dir)
     # 2025-11 must be re-exported; 2026-05 is honest and skipped.
     assert completed == {"2026-05"}
+
+
+def test_scan_completed_months_excludes_divergent_month(tmp_path: Path) -> None:
+    """A month whose JSON holds more messages than the HTML renders (issue #1
+    divergence) is NOT complete, so it re-exports and heals."""
+    import json as _json
+
+    from scripts.months import scan_completed_months
+
+    chan = tmp_path / "general"
+    month = chan / "2026-04"
+    month.mkdir(parents=True)
+    # JSON says 3 messages; HTML renders only 1 → divergent.
+    (month / "2026-04.json").write_text(
+        _json.dumps(
+            {
+                "messages": [
+                    {"id": "1", "timestamp": "2026-04-01T00:00:00+00:00"},
+                    {"id": "2", "timestamp": "2026-04-02T00:00:00+00:00"},
+                    {"id": "3", "timestamp": "2026-04-03T00:00:00+00:00"},
+                ]
+            }
+        )
+    )
+    (month / "2026-04.html").write_text("<html><div data-message-id=1>only one</div></html>")
+
+    assert scan_completed_months(chan) == set()
+
+
+def test_count_html_messages_counts_data_message_id(tmp_path: Path) -> None:
+    """count_html_messages counts DCE's unquoted data-message-id= markers and
+    ignores the chatlog__message-container- tokens in CSS/JS."""
+    from scripts.months import count_html_messages
+
+    ids = ["111", "222"]
+    html = tmp_path / "m.html"
+    html.write_text(
+        "".join(f"<div data-message-id={i}>x</div>" for i in ids)
+        + "<style>.chatlog__message-container--pinned{}</style>"
+    )
+    assert count_html_messages(html) == len(ids)
+
+
+def test_count_divergent_months(tmp_path: Path) -> None:
+    """count_divergent_months counts months where JSON and HTML counts differ."""
+    import json as _json
+
+    from scripts.months import count_divergent_months
+
+    chan = tmp_path / "general"
+    ok = chan / "2026-05"
+    ok.mkdir(parents=True)
+    (ok / "2026-05.json").write_text(_json.dumps({"messages": [{"id": "1"}]}))
+    (ok / "2026-05.html").write_text("<div data-message-id=1>x</div>")
+    bad = chan / "2026-04"
+    bad.mkdir()
+    (bad / "2026-04.json").write_text(_json.dumps({"messages": [{"id": "1"}, {"id": "2"}]}))
+    (bad / "2026-04.html").write_text("<html>blank</html>")
+
+    assert count_divergent_months(chan) == 1
 
 
 def test_scan_completed_months_treats_empty_json_as_complete(tmp_path: Path) -> None:

--- a/tests/test_organize_exports.py
+++ b/tests/test_organize_exports.py
@@ -9,7 +9,6 @@ from scripts.organize_exports import cleanup_exports, organize_exports
 # Test constants
 EXPECTED_FILES_ORGANIZED = 4
 EXPECTED_SERVERS_PROCESSED = 3
-EXPECTED_MERGED_MESSAGES = 3
 
 
 def test_organize_exports_creates_month_directory_from_filename() -> None:
@@ -396,8 +395,11 @@ def test_organize_exports_strips_cross_month_messages_during_merge() -> None:
         assert msg_300["content"] == "nov (edited)"
 
 
-def test_organize_exports_merges_json_messages_same_month() -> None:
-    """JSON merge deduplicates messages by ID for the same month."""
+def test_organize_latest_export_is_authoritative_and_drops_deleted() -> None:
+    """The latest successful export is authoritative: a message present in the
+    published archive but ABSENT from the new export is dropped (deleted on
+    Discord). This keeps the JSON consistent with the rendered HTML (issue #1);
+    the old by-ID union preserved deleted messages and desynced the count."""
     import json
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -405,13 +407,11 @@ def test_organize_exports_merges_json_messages_same_month() -> None:
         exports = tmpdir_path / "exports"
         public = tmpdir_path / "public"
 
-        # Existing 2026-05 archive
         existing_dir = public / "test-server" / "general" / "2026-05"
         existing_dir.mkdir(parents=True)
         existing_json = {
             "guild": {"id": "123"},
             "channel": {"id": "456", "name": "general"},
-            "dateRange": {"after": None, "before": None},
             "messages": [
                 {"id": "1000", "content": "First", "timestamp": "2026-05-01T00:00:00"},
                 {"id": "1001", "content": "Second", "timestamp": "2026-05-02T00:00:00"},
@@ -420,7 +420,7 @@ def test_organize_exports_merges_json_messages_same_month() -> None:
         }
         (existing_dir / "2026-05.json").write_text(json.dumps(existing_json))
 
-        # New per-month export for same month with overlap
+        # New per-month export: 1000 edited, 1001 gone (deleted), 1002 added.
         channel_dir = exports / "test-server" / "general"
         channel_dir.mkdir(parents=True)
         new_json = {
@@ -437,10 +437,50 @@ def test_organize_exports_merges_json_messages_same_month() -> None:
 
         organize_exports(exports, public)
 
-        merged = json.loads((existing_dir / "2026-05.json").read_text())
-        assert merged["messageCount"] == EXPECTED_MERGED_MESSAGES
-        ids = [m["id"] for m in merged["messages"]]
-        assert ids == ["1000", "1001", "1002"]
-        # New version of message 1000 wins
-        msg_1000 = next(m for m in merged["messages"] if m["id"] == "1000")
+        result = json.loads((existing_dir / "2026-05.json").read_text())
+        ids = [m["id"] for m in result["messages"]]
+        # 1001 absent from the new export is dropped; no preservation.
+        assert ids == ["1000", "1002"]
+        msg_1000 = next(m for m in result["messages"] if m["id"] == "1000")
         assert msg_1000["content"] == "First (edited)"
+
+
+def test_organize_transient_empty_keeps_nonempty_month() -> None:
+    """A non-empty published month re-exporting to EMPTY is treated as a
+    transient/partial fetch: the existing export is kept and an error surfaced,
+    rather than blanking the page (issue #1 transient guard)."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        exports = tmpdir_path / "exports"
+        public = tmpdir_path / "public"
+
+        existing_dir = public / "test-server" / "general" / "2026-05"
+        existing_dir.mkdir(parents=True)
+        existing_json = {
+            "channel": {"id": "456"},
+            "messages": [
+                {"id": "1000", "content": "kept", "timestamp": "2026-05-01T00:00:00"},
+                {"id": "1001", "content": "kept2", "timestamp": "2026-05-02T00:00:00"},
+            ],
+            "messageCount": 2,
+        }
+        (existing_dir / "2026-05.json").write_text(json.dumps(existing_json))
+        (existing_dir / "2026-05.html").write_text("<html>real content</html>")
+
+        # New export of the same month is EMPTY (a transient/partial fetch).
+        channel_dir = exports / "test-server" / "general"
+        channel_dir.mkdir(parents=True)
+        empty_json = {"channel": {"id": "456"}, "messages": [], "messageCount": 0}
+        (channel_dir / "2026-05.json").write_text(json.dumps(empty_json))
+        (channel_dir / "2026-05.html").write_text("<html>empty</html>")
+
+        stats = organize_exports(exports, public)
+
+        # Existing JSON and HTML are untouched (not blanked).
+        result = json.loads((existing_dir / "2026-05.json").read_text())
+        assert [m["id"] for m in result["messages"]] == ["1000", "1001"]
+        assert (existing_dir / "2026-05.html").read_text() == "<html>real content</html>"
+        # And the regression is surfaced as an error.
+        assert any("transient" in e for e in stats["errors"])


### PR DESCRIPTION
The published archive's index message counts (read from the JSON) didn't match the rendered archive pages (the HTML). Measured live: roughly a third of channel-months diverge, always `only_json > 0` (JSON holds messages the HTML never rendered) — in the worst cases a **blank page for hundreds of messages** (e.g. `general/2025-12`: 758 in JSON, 0 rendered).

## Root cause
`organize_exports._merge_json_exports()` *unioned* messages by ID across runs (preserving any in-month message even if the latest export dropped it), while HTML/txt/csv were copied wholesale. The JSON accreted; the HTML was a snapshot of the last export. They drifted.

## Fix (this PR)
- **organize:** publish a month's four formats **atomically** from the same export; drop the by-ID union. The latest *successful* export is authoritative — deletions propagate, JSON stays consistent with the rendered HTML. **Transient guard:** a non-empty month re-exporting to *empty* is treated as a partial/transient fetch (keep existing, surface an error) rather than blanking the page.
- **months.py:** a month is "completed" only if its JSON message count equals the HTML rendered count (`data-message-id` markers). Divergent months become incomplete → the existing backfill re-exports and **heals** them. New: `count_html_messages`, `count_divergent_months`.
- **export_channels:** backfill **prioritizes** channels/threads with divergent months, so the visible blank/short pages heal first.

## Decisions (owner)
Deletions propagate (not a high-water-mark); transient/partial = error. Per the owner's call, the **CI consistency check lands in a follow-up** once the backlog self-heals — adding it now would keep runs red for the multi-run heal.

## Tests
- organize: authoritative replace drops messages absent from the new export; transient-empty keeps the existing month + records an error.
- months: divergent month excluded from `completed`; `count_html_messages` / `count_divergent_months`.
- Full suite: 173 passed; ruff/format/mypy clean.

PR 2 of the archive-correctness series (the #1 fix half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)