### PR TITLE
feat: group server index by category in guild order (#5)

### DIFF
--- a/scripts/export_channels.py
+++ b/scripts/export_channels.py
@@ -871,6 +871,46 @@ def fetch_guild_channels(  # noqa: C901  # Complex parsing of DiscordChatExporte
         raise RuntimeError(f"Channel fetching failed: {str(e)}") from e
 
 
+def write_channel_order(
+    public_dir: Path,
+    server_key: str,
+    channels: list[dict[str, str | None]],
+    classifications: dict[str, ChannelType],
+    channel_path_map: dict[str, str],
+) -> None:
+    """Persist the guild's channel order + category for the navigation index.
+
+    DCE lists channels in the guild's own order; navigation otherwise rederives
+    structure from the filesystem and loses it (issue #5). We record the ordered
+    list of non-thread channel paths with their category so navigation can group
+    channels by category and sort them the way the server does. Threads are
+    excluded — they nest under their channel, not at the top level. Best-effort:
+    a write failure must never abort the export.
+    """
+    import json as _json
+
+    order: list[dict[str, str]] = []
+    for ch in channels:
+        cid = ch.get("id")
+        name = ch.get("name")
+        if not cid or not name:
+            continue
+        if classifications.get(cid) == ChannelType.THREAD:
+            continue
+        path = channel_path_map.get(name, name)
+        category = path.rsplit("/", 1)[0] if "/" in path else ""
+        order.append({"path": path, "category": category})
+
+    try:
+        server_pub = public_dir / server_key
+        server_pub.mkdir(parents=True, exist_ok=True)
+        with open(server_pub / "_order.json", "w", encoding="utf-8") as f:
+            _json.dump(order, f, indent=2)
+        print(f"  ✓ Wrote channel order ({len(order)} channels) for navigation")
+    except OSError as e:
+        print(f"  ⚠ could not write channel order sidecar: {e}")
+
+
 def export_all_channels(  # noqa: C901,PLR0915  # Orchestration top-level
     public_dir: Path | None = None,
     max_runtime_seconds: int | None = None,
@@ -976,6 +1016,12 @@ def export_all_channels(  # noqa: C901,PLR0915  # Orchestration top-level
                 continue
             channel_type = classify_channel(channel, forum_list, channels)
             channel_classifications[chan_id] = channel_type
+
+        # Persist the guild's channel order so navigation can group channels by
+        # category and sort them the way the server does (issue #5).
+        write_channel_order(
+            public_dir, server_key, channels, channel_classifications, channel_path_map
+        )
 
         # Two-phase processing so the live site stays fresh everywhere even
         # when the historical backfill can't finish in one workflow window:

--- a/scripts/generate_navigation.py
+++ b/scripts/generate_navigation.py
@@ -310,21 +310,76 @@ def generate_cname_file(config: dict, output_path: Path) -> None:
         print(f"✓ Generated CNAME file for {parsed.hostname}")
 
 
+def load_channel_order(public_dir: Path, server_name: str) -> list[str]:
+    """Return channel paths in guild order from the export's `_order.json`.
+
+    Empty list if the sidecar is absent or unreadable — navigation then falls
+    back to alphabetical ordering, so a missing sidecar degrades gracefully.
+    """
+    order_file = public_dir / server_name / "_order.json"
+    try:
+        with open(order_file, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    return [e["path"] for e in data if isinstance(e, dict) and e.get("path")]
+
+
+def group_channels_by_category(channels: list[dict], order: list[str]) -> list[dict]:
+    """Group channels under their category, ordered the way the guild is.
+
+    `order` is the list of channel paths in guild order (from the export
+    sidecar). Categories appear in the order their first channel appears.
+    Channels missing from `order` (e.g. brand new, not yet in the latest
+    export) sort to the end of their category alphabetically, so nothing is
+    ever dropped. Returns `[{"name": category, "channels": [...]}, ...]`.
+    """
+    pos = {path: i for i, path in enumerate(order)}
+    fallback = len(order)
+
+    groups: dict[str, list[dict]] = {}
+    cat_order: list[str] = []
+    for ch in sorted(channels, key=lambda c: (pos.get(c["name"], fallback), c["name"])):
+        cat = ch.get("category") or ""
+        if cat not in groups:
+            groups[cat] = []
+            cat_order.append(cat)
+        groups[cat].append(ch)
+
+    return [{"name": cat, "channels": groups[cat]} for cat in cat_order]
+
+
 def generate_server_index(
-    config: dict, server: dict, channels: list[dict], output_path: Path
+    config: dict,
+    server: dict,
+    channels: list[dict],
+    output_path: Path,
+    categories: list[dict] | None = None,
 ) -> None:
     """Generate server index page.
 
     Args:
         config: Site configuration
         server: Server info dict
-        channels: List of channel info dicts
+        channels: List of channel info dicts (flat; kept for back-compat)
         output_path: Where to write index.html
+        categories: Channels grouped by category in guild order (issue #5);
+            the template renders these as labelled sections.
     """
     env = Environment(loader=FileSystemLoader("templates"))
     template = env.get_template("server_index.html.j2")
 
-    html = template.render(site=config["site"], server=server, channels=channels)
+    # Self-sufficient: with no explicit guild order, group channels by their
+    # own category field (alphabetical) so the page still renders grouped.
+    if categories is None:
+        categories = group_channels_by_category(channels, [])
+
+    html = template.render(
+        site=config["site"],
+        server=server,
+        channels=channels,
+        categories=categories,
+    )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(html)
@@ -743,11 +798,17 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915  # Main orchestration functi
                 channel["is_forum"] = channel["total_messages"] == 0 and len(channel["threads"]) > 0
                 channel["thread_count"] = len(channel["threads"])
 
+            # Group channels by category in the guild's own order (issue #5);
+            # falls back to the alphabetical channels_list when no sidecar.
+            order = load_channel_order(public_dir, server_name)
+            categories = group_channels_by_category(channels_list, order)
+
             generate_server_index(
                 config,
                 server_data,
                 channels_list,
                 public_dir / server_name / "index.html",
+                categories=categories,
             )
 
             thread_pages = 0

--- a/templates/server_index.html.j2
+++ b/templates/server_index.html.j2
@@ -16,12 +16,12 @@
     </header>
 
     <main>
-        <section class="channels">
-            <h2>Channels</h2>
-            {% for channel in channels %}
+        {% for category in categories %}
+        <section class="category-group">
+            <h2 class="category-heading">{% if category.name %}{{ category.name }}{% else %}Other channels{% endif %}</h2>
+            {% for channel in category.channels %}
             <div class="channel-card">
                 <h3><a href="/{{ server.name }}/{{ channel.name }}/index.html">{% if channel.is_forum %}📋 {% else %}#{% endif %}{{ channel.display_name or channel.name }}</a></h3>
-                {% if channel.category %}<p class="category">in {{ channel.category }}</p>{% endif %}
                 {% if channel.is_forum %}
                 <p class="stats">Forum with discussion threads</p>
                 <p><a href="/{{ server.name }}/{{ channel.name }}/index.html">View all threads →</a></p>
@@ -52,6 +52,7 @@
             </div>
             {% endfor %}
         </section>
+        {% endfor %}
     </main>
 
     <footer>

--- a/tests/test_export_channels.py
+++ b/tests/test_export_channels.py
@@ -173,6 +173,42 @@ def test_export_one_month_current_month_is_bounded(tmp_path: Path) -> None:
     assert "2026-07-01T00:00:00+00:00" in cmd
 
 
+def test_write_channel_order_captures_guild_order_and_category(tmp_path: Path) -> None:
+    """write_channel_order records non-thread channels in guild order with their
+    category, so navigation can group + sort like the server (issue #5)."""
+    import json
+
+    from scripts.channel_classifier import ChannelType
+    from scripts.export_channels import write_channel_order
+
+    channels: list[dict[str, str | None]] = [
+        {"name": "general", "id": "1", "parent_id": "Information"},
+        {"name": "questions", "id": "2", "parent_id": "Information"},
+        {"name": "How to?", "id": "3", "parent_id": "questions"},  # a thread
+        {"name": "analog", "id": "4", "parent_id": "Designing"},
+    ]
+    classifications = {
+        "1": ChannelType.REGULAR,
+        "2": ChannelType.FORUM,
+        "3": ChannelType.THREAD,
+        "4": ChannelType.REGULAR,
+    }
+    path_map = {
+        "general": "Information/general",
+        "questions": "Information/questions",
+        "analog": "Designing/analog",
+    }
+    write_channel_order(tmp_path, "wafer-space", channels, classifications, path_map)
+
+    order = json.loads((tmp_path / "wafer-space" / "_order.json").read_text())
+    # Threads excluded; guild order preserved; category derived from the path.
+    assert order == [
+        {"path": "Information/general", "category": "Information"},
+        {"path": "Information/questions", "category": "Information"},
+        {"path": "Designing/analog", "category": "Designing"},
+    ]
+
+
 def test_format_export_command_invalid_format() -> None:
     """Test that invalid format_type raises ValueError"""
     with pytest.raises(ValueError, match="Invalid format_type"):

--- a/tests/test_generate_navigation.py
+++ b/tests/test_generate_navigation.py
@@ -415,3 +415,53 @@ def test_collect_forum_threads_empty_directory() -> None:
         threads = collect_forum_threads(forum_dir)
 
         assert threads == []
+
+
+def test_group_channels_by_category_orders_by_guild_order() -> None:
+    """Channels group under their category, categories and channels ordered the
+    way the guild lists them (issue #5)."""
+    from scripts.generate_navigation import group_channels_by_category
+
+    channels = [
+        {"name": "Information/general", "category": "Information"},
+        {"name": "Designing/analog", "category": "Designing"},
+        {"name": "Information/questions", "category": "Information"},
+    ]
+    order = ["Information/general", "Information/questions", "Designing/analog"]
+
+    groups = group_channels_by_category(channels, order)
+
+    assert [g["name"] for g in groups] == ["Information", "Designing"]
+    assert [c["name"] for c in groups[0]["channels"]] == [
+        "Information/general",
+        "Information/questions",
+    ]
+    assert [c["name"] for c in groups[1]["channels"]] == ["Designing/analog"]
+
+
+def test_group_channels_unknown_sorts_last_alphabetically() -> None:
+    """A channel missing from the guild order (e.g. brand new) sorts to the end
+    of its category alphabetically — never dropped."""
+    from scripts.generate_navigation import group_channels_by_category
+
+    channels = [
+        {"name": "Information/zeta", "category": "Information"},
+        {"name": "Information/alpha", "category": "Information"},  # not in order
+        {"name": "Information/general", "category": "Information"},
+    ]
+    order = ["Information/general", "Information/zeta"]
+
+    groups = group_channels_by_category(channels, order)
+
+    assert [c["name"] for c in groups[0]["channels"]] == [
+        "Information/general",
+        "Information/zeta",
+        "Information/alpha",
+    ]
+
+
+def test_load_channel_order_missing_is_empty(tmp_path: Path) -> None:
+    """A missing sidecar yields an empty order (alphabetical fallback)."""
+    from scripts.generate_navigation import load_channel_order
+
+    assert load_channel_order(tmp_path, "nope") == []

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -69,25 +69,27 @@ def test_server_index_template_renders() -> None:
     env = Environment(loader=FileSystemLoader("templates"))
     template = env.get_template("server_index.html.j2")
 
+    channel = {
+        "name": "general",
+        "display_name": "general",
+        "message_count": 100,
+        "archive_count": 3,
+        "archives": [
+            {"date": "2025-01", "message_count": 50},
+            {"date": "2024-12", "message_count": 30},
+        ],
+    }
     html = template.render(
         site={"title": "Test Site"},
         server={"name": "test-server", "display_name": "Test Server"},
-        channels=[
-            {
-                "name": "general",
-                "message_count": 100,
-                "archive_count": 3,
-                "archives": [
-                    {"date": "2025-01", "message_count": 50},
-                    {"date": "2024-12", "message_count": 30},
-                ],
-            }
-        ],
+        channels=[channel],
+        categories=[{"name": "Information", "channels": [channel]}],
     )
 
     assert "<!DOCTYPE html>" in html
     assert "Test Server" in html
     assert "#general" in html
+    assert "Information" in html  # category heading (issue #5)
 
 
 def test_channel_index_template_renders() -> None:


### PR DESCRIPTION
The server index listed all channels in one **flat, alphabetical list** (with a small "in <category>" note), ignoring the server's category grouping and order.

## Fix
- **Capture (export):** `write_channel_order()` persists the ordered, categorized list of non-thread channels to `public/<server>/_order.json` — DCE lists channels in the guild's own order, which navigation otherwise loses by rederiving structure from the filesystem.
- **Consume (nav):** `load_channel_order()` + `group_channels_by_category()` group channels under their category, with categories and channels ordered the way the guild lists them. Channels missing from the sidecar (e.g. brand new) sort to the end of their category alphabetically — never dropped. Graceful fallback to alphabetical when the sidecar is absent.
- **Template:** renders labelled category sections instead of a flat list.

## Note on ordering
The order comes from DCE's `channels` listing (the guild's order). I'll verify on the live site after deploy that this matches the server's visual order; if DCE's order turns out not to be positional, the follow-up is to capture Discord channel `position` directly. Category **grouping** is correct regardless.

## Tests
- order capture excludes threads, preserves order, derives category;
- grouping orders categories/channels by guild order; unknown channels sort last alphabetically; missing sidecar → empty;
- server-index template renders category headings.
- Full suite: 177 passed; ruff/format/mypy clean.

PR 4 of the archive-correctness series (#5). Remaining: #2 (normal-channel threads, needs a real `channels` dump) and the #1 consistency *check* (after the self-heal converges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)