### PR TITLE
fix: re-export American-date months to convert the archive to ISO (#3)

### DIFF
--- a/scripts/months.py
+++ b/scripts/months.py
@@ -39,6 +39,12 @@ _MONTH_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
 # message count to detect the issue-#1 JSON/HTML divergence.
 _HTML_MESSAGE_RE = re.compile(rb"data-message-id=(\d+)")
 
+# DCE renders dates per --locale: the en-CA fix produces ISO yyyy-MM-dd, while
+# pre-fix exports produced US MM/dd/yyyy. We compare counts (not mere presence)
+# so a stray date typed into a message never misclassifies an otherwise-ISO page.
+_ISO_DATE_RE = re.compile(rb"\d{4}-\d{2}-\d{2}")
+_US_DATE_RE = re.compile(rb"\d{1,2}/\d{1,2}/\d{4}")
+
 
 def _parse_month(month: str) -> tuple[int, int]:
     """Parse a "YYYY-MM" string into (year, month) ints.
@@ -149,6 +155,10 @@ def scan_completed_months(channel_dir: Path) -> set[str]:
             # renders), treat the month as incomplete so it re-exports and heals.
             if not _month_is_consistent(json_file, html_file):
                 continue
+        # Re-export months still rendered with American dates so they convert to
+        # ISO (issue #3) — the --locale fix only reaches a month on re-export.
+        if _html_uses_american_dates(html_file):
+            continue
         completed.add(entry.name)
     return completed
 
@@ -227,6 +237,21 @@ def count_html_messages(html_file: Path) -> int:
     except OSError:
         return 0
     return len(_HTML_MESSAGE_RE.findall(data))
+
+
+def _html_uses_american_dates(html_file: Path) -> bool:
+    """True if the HTML's dominant date format is US MM/DD/YYYY rather than ISO.
+
+    A pre-`--locale en-CA` export rendered dates American-style and must be
+    re-exported to convert to ISO (issue #3), since the date fix only reaches a
+    month on re-export. We compare US vs ISO date counts so a single date typed
+    into a message never flips an otherwise-ISO page.
+    """
+    try:
+        data = html_file.read_bytes()
+    except OSError:
+        return False
+    return len(_US_DATE_RE.findall(data)) > len(_ISO_DATE_RE.findall(data))
 
 
 def _month_is_consistent(json_file: Path, html_file: Path) -> bool:

--- a/tests/test_months.py
+++ b/tests/test_months.py
@@ -332,3 +332,42 @@ def test_count_nonempty_months_missing_dir_is_zero(tmp_path: Path) -> None:
     from scripts.months import count_nonempty_months
 
     assert count_nonempty_months(tmp_path / "nope") == 0
+
+
+def test_html_uses_american_dates(tmp_path: Path) -> None:
+    """Detect the dominant date format: US MM/DD/YYYY vs ISO YYYY-MM-DD (#3)."""
+    from scripts.months import _html_uses_american_dates
+
+    us = tmp_path / "us.html"
+    us.write_text("After 04/30/2026 23:59 ... 05/01/2026 ... 05/02/2026")
+    assert _html_uses_american_dates(us) is True
+
+    iso = tmp_path / "iso.html"
+    iso.write_text("Between 2026-04-30 and 2026-06-01 ... 2026-05-02 ... 2026-05-03")
+    assert _html_uses_american_dates(iso) is False
+
+    # An otherwise-ISO page with one date typed into a message stays ISO.
+    mixed = tmp_path / "mixed.html"
+    mixed.write_text("2026-05-01 2026-05-02 2026-05-03 see you 12/25/2024")
+    assert _html_uses_american_dates(mixed) is False
+
+
+def test_scan_completed_excludes_american_date_month(tmp_path: Path) -> None:
+    """A consistent month still rendered with American dates is incomplete, so
+    it re-exports and converts to ISO (issue #3)."""
+    import json as _json
+
+    from scripts.months import scan_completed_months
+
+    chan = tmp_path / "general"
+    month = chan / "2026-05"
+    month.mkdir(parents=True)
+    (month / "2026-05.json").write_text(
+        _json.dumps({"messages": [{"id": "1", "timestamp": "2026-05-02T00:00:00+00:00"}]})
+    )
+    # HTML is consistent (1 rendered message) but American-style dates.
+    (month / "2026-05.html").write_text(
+        "<div data-message-id=1>After 04/30/2026 23:59 - 05/02/2026 6:39</div>"
+    )
+
+    assert scan_completed_months(chan) == set()


### PR DESCRIPTION
Completes #3. The `--locale en-CA` fix (PR #10) makes new exports ISO, and the #1 consistency heal (PR #11) re-exports divergent + current months — so those are now ISO. But months that were always content-consistent keep their old **American MM/DD/YYYY** HTML, because the date fix only reaches a month on re-export.

Per the owner's call (**force full conversion**), extend the self-heal: `scan_completed_months` now treats a month as incomplete if its HTML's **dominant** date format is US rather than ISO, so the backfill re-exports it and the dates convert to ISO.

Detection compares US vs ISO date *counts* (not mere presence), so a single date typed into a message never flips an otherwise-ISO page.

## Effect
Queues a large one-time backfill — most archived months are still American — converging the whole archive to ISO over subsequent runs, after the higher-priority content (#1) heal. Runs stay green throughout.

## Tests
- `_html_uses_american_dates`: US page → True, ISO page → False, ISO page with one typed US date → False.
- `scan_completed_months` excludes a consistent-but-American month.
- Full suite: 179 passed; ruff/format/mypy clean.

PR 5 of the series. Remaining: #2 (normal-channel threads — needs the `channels` dump) and the #1 consistency *check* (after the heal converges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)